### PR TITLE
Rename IRBasis -> DimensionlessBasis

### DIFF
--- a/dump.py
+++ b/dump.py
@@ -24,8 +24,8 @@ def run():
 
     kernel = sparse_ir.LogisticKernel(lambda_)
     sve_result = sparse_ir.compute_sve(kernel, eps)
-    basis_f = sparse_ir.IRBasis("F", lambda_, eps, kernel=kernel, sve_result=sve_result)
-    basis_b = sparse_ir.IRBasis("B", lambda_, eps, kernel=kernel, sve_result=sve_result)
+    basis_f = sparse_ir.DimensionlessBasis("F", lambda_, eps, kernel=kernel, sve_result=sve_result)
+    basis_b = sparse_ir.DimensionlessBasis("B", lambda_, eps, kernel=kernel, sve_result=sve_result)
 
     # For the logistic kernel, the fermionic and bosonic basis functions are equivalent.
     with open(args.output, "w") as f:

--- a/mk_preset.py
+++ b/mk_preset.py
@@ -15,8 +15,8 @@ class BasisInfo:
         kernel = sparse_ir.LogisticKernel(lambda_)
         sve_result = sparse_ir.compute_sve(kernel, eps)
 
-        self.basis_f = sparse_ir.IRBasis("F", lambda_, eps, kernel=kernel, sve_result=sve_result)
-        self.basis_b = sparse_ir.IRBasis("B", lambda_, eps, kernel=kernel, sve_result=sve_result)
+        self.basis_f = sparse_ir.DimensionlessBasis("F", lambda_, eps, kernel=kernel, sve_result=sve_result)
+        self.basis_b = sparse_ir.DimensionlessBasis("B", lambda_, eps, kernel=kernel, sve_result=sve_result)
         self.s = self.basis_f.s
         self.size = self.s.size
 


### PR DESCRIPTION
The module name has been changed for the new version (0.11.0) of `sparse-ir`.