### PR TITLE
New functions related to SPR are implemented.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,8 @@ on:
   - pull_request
 
 jobs:
-  build:
-    name: Run Fortran tests
+  build1:
+    name: Tests for GNU compiler + OpenBLAS
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -14,14 +14,40 @@ jobs:
         uses: actions/setup-python@v2
       - name: Install dependencies
         run: |
-            sudo apt-get --yes install ccache
-            sudo apt-get update -q -y
-            sudo apt-get install -y libopenblas-base libopenblas-dev
-            pip3 install sparse-ir xprec
-
+          sudo apt-get --yes install ccache
+          sudo apt-get update -q -y
+          sudo apt-get install -y libopenblas-base libopenblas-dev
+          pip3 install sparse-ir xprec
       - name: Test fortran interface
         run: |
           cp Makefile.gfortran_openblas Makefile
+          pwd
+          ls -l
+          ./runtest.sh
+
+  build2:
+    name: Tests for Intel compiler + Intel MKL
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up python
+        uses: actions/setup-python@v2
+      - name: Set up repo
+        run: |
+          wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+          sudo apt-get update
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y intel-oneapi-common-vars
+          sudo apt-get install -y intel-oneapi-compiler-fortran
+          sudo apt-get install -y intel-oneapi-mkl-devel
+          source /opt/intel/oneapi/setvars.sh
+          printenv >> $GITHUB_ENV
+          pip3 install sparse-ir xprec
+      - name: "Test fortran interface"
+        run: |
+          cp Makefile.ifort_mkl Makefile
           pwd
           ls -l
           ./runtest.sh

--- a/Makefile.gfortran_openblas
+++ b/Makefile.gfortran_openblas
@@ -2,7 +2,7 @@ FC = gfortran
 
 LDLIBS = -lblas -llapack
 LDFLAGS = -L/usr/lib/x86_64-linux-gnu
-F90FLAGS = -std=f2008 -Wall -fbounds-check -g -fcheck=array-temps,bounds,do,mem,pointer,recursion
+F90FLAGS = -std=f2003 -Wall -fbounds-check -g -fcheck=array-temps,bounds,do,mem,pointer,recursion
 
 TARGET = test_sparse_ir
 OBJS = test_sparse_ir.o sparse_ir.o sparse_ir_io.o sparse_ir_preset.o

--- a/Makefile.ifort_mkl
+++ b/Makefile.ifort_mkl
@@ -1,8 +1,9 @@
-FC = gfortran
+FC = ifort
 
-LDLIBS = -lblas -llapack
-LDFLAGS = -L/usr/lib/x86_64-linux-gnu
-F90FLAGS = -std=f2008 -Wall -fbounds-check -g -fcheck=array-temps,bounds,do,mem,pointer,recursion
+LDLIBS = -L${MKLROOT}/lib/intel64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
+#LDLIBS = -mkl=sequential
+LDFLAGS = -static-intel
+F90FLAGS = -O2 -g -traceback
 
 TARGET = test_sparse_ir
 OBJS = test_sparse_ir.o sparse_ir.o sparse_ir_io.o sparse_ir_preset.o

--- a/dump.py
+++ b/dump.py
@@ -64,6 +64,19 @@ def run():
                 for i in range(freqs.size):
                     print('{:.16e} {:.16e}'.
                         format(uhatval[l, i].real, uhatval[l, i].imag), file=f)
+        
+        print(f"# sampling poles", file=f)
+        #   Add w_p = -wmax, +wmax to sampling poles
+        omega = np.unique(np.hstack([-1, basis_f.default_omega_sampling_points(), 1]))
+        print(omega.size, file=f)
+        for x in omega:
+            print('{:.16e}'.format(x), file=f)
+
+        print(f"# v", file=f)
+        vval = basis_f.v(omega)
+        for l in range(basis_f.size):
+            for i in range(omega.size):
+                print('{:.16e}'.format(vval[l, i]), file=f)
 
 if __name__ == '__main__':
     run()

--- a/sparse_ir.f90
+++ b/sparse_ir.f90
@@ -11,22 +11,25 @@ module sparse_ir
 
     ! Sampling points, basis functions
     type IR
-        integer :: size, ntau, nfreq_f, nfreq_b
+        integer :: size, ntau, nfreq_f, nfreq_b, nomega
         double precision :: beta, lambda, wmax, eps, eps_svd
         double precision, pointer :: s(:), tau(:), x(:)
+        double precision, pointer :: omega(:), y(:)
         integer, pointer :: freq_f(:), freq_b(:)
         complex(kind(0d0)), pointer :: u_data(:,:)
         complex(kind(0d0)), pointer :: uhat_f_data(:,:), uhat_b_data(:,:)
+        complex(kind(0d0)), pointer :: v_data(:,:), spr_data(:,:)
         type(DecomposedMatrix) :: u
         type(DecomposedMatrix) :: uhat_f, uhat_b
+        type(DecomposedMatrix) :: spr
     end type
 
     contains
 
-    subroutine init_ir(obj, beta, lambda, eps, s, x, freq_f, freq_b, u, uhat_f, uhat_b, eps_svd)
+    subroutine init_ir(obj, beta, lambda, eps, s, x, freq_f, freq_b, u, uhat_f, uhat_b, y, v, spr, eps_svd)
         type(IR), intent(inout) :: obj
-        double precision, intent(in) :: beta, lambda, eps, s(:), x(:), eps_svd
-        complex(kind(0d0)), intent(in) :: u(:,:), uhat_f(:, :), uhat_b(:, :)
+        double precision, intent(in) :: beta, lambda, eps, s(:), x(:), y(:), eps_svd
+        complex(kind(0d0)), intent(in) :: u(:,:), uhat_f(:, :), uhat_b(:, :), v(:, :), spr(:, :)
         integer, intent(in) :: freq_f(:), freq_b(:)
 
         obj%size = size(s)
@@ -36,6 +39,7 @@ module sparse_ir
         obj%lambda = lambda
         obj%eps = eps
         obj%eps_svd = eps_svd
+        obj%nomega = size(y)
 
         allocate(obj%x(obj%ntau))
         obj%x = x
@@ -60,6 +64,17 @@ module sparse_ir
         allocate(obj%uhat_b_data(obj%nfreq_b, obj%size))
         obj%uhat_b_data = uhat_b
 
+        allocate(obj%y(obj%nomega))
+        obj%y = y
+
+        allocate(obj%omega(obj%nomega))
+
+        allocate(obj%v_data(obj%nomega, obj%size))
+        obj%v_data = v
+
+        allocate(obj%spr_data(obj%size, obj%nomega))
+        obj%spr_data = transpose(spr)
+
         ! Here we define basis sets for the input value of beta. 
         call set_beta(obj, beta)
     end subroutine
@@ -72,10 +87,61 @@ module sparse_ir
         obj%wmax = obj%lambda / beta
 
         obj%tau = 5.0d-1 * beta * (obj%x + 1.d0)
+        obj%omega = obj%y * obj%wmax
 
         obj%u = decompose(sqrt(2.0d0/beta)*obj%u_data, obj%eps_svd)
         obj%uhat_f = decompose(sqrt(beta) * obj%uhat_f_data, obj%eps_svd)
         obj%uhat_b = decompose(sqrt(beta) * obj%uhat_b_data, obj%eps_svd)
+        obj%spr = decompose2(sqrt(5.0d-1*beta)*obj%spr_data, obj%eps_svd)
+    end subroutine
+
+    subroutine finalize_ir(obj)
+        type(IR) :: obj
+
+        if (allocated(obj%x)) deallocate(obj%x)
+        if (allocated(obj%tau)) deallocate(obj%tau)
+        if (allocated(obj%s)) deallocate(obj%s)
+        if (allocated(obj%freq_f)) deallocate(obj%freq_f)
+        if (allocated(obj%freq_b)) deallocate(obj%freq_b)
+        if (allocated(obj%u_data)) deallocate(obj%u_data)
+        if (allocated(obj%uhat_f_data)) deallocate(obj%uhat_f_data)
+        if (allocated(obj%uhat_b_data)) deallocate(obj%uhat_b_data)
+        if (allocated(obj%y)) deallocate(obj%y)
+        if (allocated(obj%omega)) deallocate(obj%omega)
+        if (allocated(obj%v_data)) deallocate(obj%v_data)
+        if (allocated(obj%spr_data)) deallocate(obj%spr_data)
+
+        if (associated(obj%x)) nullify(obj%x)
+        if (associated(obj%tau)) nullify(obj%tau)
+        if (associated(obj%s)) nullify(obj%s)
+        if (associated(obj%freq_f)) nullify(obj%freq_f)
+        if (associated(obj%freq_b)) nullify(obj%freq_b)
+        if (associated(obj%u_data)) nullify(obj%u_data)
+        if (associated(obj%uhat_f_data)) nullify(obj%uhat_f_data)
+        if (associated(obj%uhat_b_data)) nullify(obj%uhat_b_data)
+        if (associated(obj%y)) nullify(obj%y)
+        if (associated(obj%omega)) nullify(obj%omega)
+        if (associated(obj%v_data)) nullify(obj%v_data)
+        if (associated(obj%spr_data)) nullify(obj%spr_data)
+
+        call finalize_dmat(obj%u)
+        call finalize_dmat(obj%uhat_f)
+        call finalize_dmat(obj%uhat_b)
+        call finalize_dmat(obj%spr)
+    end subroutine
+
+    subroutine finalize_dmat(dmat)
+        type(DecomposedMatrix) :: dmat
+      
+        if (allocated(dmat%a)) deallocate(dmat%a)
+        if (allocated(dmat%inv_s)) deallocate(dmat%inv_s)
+        if (allocated(dmat%ut)) deallocate(dmat%ut)
+        if (allocated(dmat%v)) deallocate(dmat%v)
+      
+        if (associated(dmat%a)) nullify(dmat%a)
+        if (associated(dmat%inv_s)) nullify(dmat%inv_s)
+        if (associated(dmat%ut)) nullify(dmat%ut)
+        if (associated(dmat%v)) nullify(dmat%v)
     end subroutine
 
     ! SVD of matrix a. Singular values smaller than eps * the largest one are dropped.
@@ -132,6 +198,59 @@ module sparse_ir
         deallocate(work, a_copy, s, u, vt, rwork, iwork)
     end function
 
+    ! SVD of matrix a. Singular values smaller than eps * the largest one are dropped.
+    function decompose2(a, eps) result(dmat)
+        complex(kind(0d0)), intent(in) :: a(:, :)
+        double precision, intent(in) :: eps
+    
+        integer :: i, info, lda, ldu, ldvt, lwork, m, n, mn, ns
+        complex(kind(0d0)), allocatable :: a_copy(:, :), u(:, :), &
+            vt(:, :), work(:)
+        double precision, allocatable :: rwork(:), s(:)
+        type(DecomposedMatrix)::dmat
+    
+        m = size(a, 1)
+        n = size(a, 2)
+        mn = min(m, n)
+        lda = m
+        ldu = m
+        ldvt = n
+        lwork = 2*mn + m + n
+    
+        allocate(work(lwork), a_copy(m,n), s(m), u(ldu,m), vt(ldvt,n), rwork(5*n))
+    
+        a_copy(1:m, 1:n) = a(1:m, 1:n)
+        call zgesvd('S', 'S', m, n, a_copy, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, info)
+    
+        if (info /= 0) then
+            stop 'Failure in ZGESVD.'
+        end if
+    
+        ! Number of relevant singular values s(i)/s(1) >= eps
+        ns = 0
+        do i = 1, mn
+            if (s(i)/s(1) < eps) then
+                exit
+            end if
+            ns = ns + 1
+        end do
+    
+        allocate(dmat%a(m, n))
+        allocate(dmat%inv_s(ns))
+        allocate(dmat%ut(ns, m))
+        allocate(dmat%v(n, ns))
+    
+        dmat%a = a
+        dmat%inv_s(1:ns) = 1.0D0 / s(1:ns)
+        dmat%ut(1:ns, 1:m) = conjg(transpose(u(1:m, 1:ns)))
+        dmat%v(1:n, 1:ns) = conjg(transpose(vt(1:ns, 1:n)))
+        dmat%m = size(a, 1)
+        dmat%n = size(a, 2)
+        dmat%ns = ns
+    
+        deallocate(work, a_copy, s, u, vt, rwork)
+    end function
+
     subroutine fit_matsubara_f(obj, arr, res)
         type(IR), intent(in) :: obj
         complex(kind(0d0)), intent (in) :: arr(:, :)
@@ -165,9 +284,9 @@ module sparse_ir
         n = size(arr, 2)
         l2 = size(res, 1)
         m = size(res, 2)
-        IF (l1 .NE. l2) stop 'wrong number of rows of input matrix.'
-        IF (n .NE. obj%u%n) stop 'wrong number of columns of input matrix.'
-        IF (m .NE. obj%u%m) stop 'wrong number of columns of output matrix.'
+        IF (l1 .NE. l2) stop 'wrong number of rows of input array.'
+        IF (n .NE. obj%u%n) stop 'wrong number of columns of input array.'
+        IF (m .NE. obj%u%m) stop 'wrong number of columns of output array.'
         !
         CALL ZGEMM('n', 't', l1, m, n, cone, arr(:,:), &
                    l2, obj%u%a, m, czero, res(:, :), l2)
@@ -186,9 +305,9 @@ module sparse_ir
         n = size(arr, 2)
         l2 = size(res, 1)
         m = size(res, 2)
-        IF (l1 .NE. l2) stop 'wrong number of rows of input matrix.'
-        IF (n .NE. obj%uhat_f%n) stop 'wrong number of columns of input matrix.'
-        IF (m .NE. obj%uhat_f%m) stop 'wrong number of columns of output matrix.'
+        IF (l1 .NE. l2) stop 'wrong number of rows of input array.'
+        IF (n .NE. obj%uhat_f%n) stop 'wrong number of columns of input array.'
+        IF (m .NE. obj%uhat_f%m) stop 'wrong number of columns of output array.'
         !
         CALL ZGEMM('n', 't', l1, m, n, cone, arr(:,:), &
                    l2, obj%uhat_f%a, m, czero, res(:, :), l2)
@@ -207,9 +326,9 @@ module sparse_ir
         n = size(arr, 2)
         l2 = size(res, 1)
         m = size(res, 2)
-        IF (l1 .NE. l2) stop 'wrong number of rows of input matrix.'
-        IF (n .NE. obj%uhat_b%n) stop 'wrong number of columns of input matrix.'
-        IF (m .NE. obj%uhat_b%m) stop 'wrong number of columns of output matrix.'
+        IF (l1 .NE. l2) stop 'wrong number of rows of input array.'
+        IF (n .NE. obj%uhat_b%n) stop 'wrong number of columns of input array.'
+        IF (m .NE. obj%uhat_b%m) stop 'wrong number of columns of output array.'
         !
         CALL ZGEMM('n', 't', l1, m, n, cone, arr(:,:), &
                    l2, obj%uhat_b%a, m, czero, res(:, :), l2)
@@ -258,5 +377,115 @@ module sparse_ir
         deallocate(ut_arr)
     end subroutine
 
+    subroutine to_spr(obj, arr, res)
+        type(IR), intent(in) :: obj
+        complex(kind(0d0)), intent (in) :: arr(:, :)
+        complex(kind(0d0)), intent(out) :: res(:, :)
+        call fit_impl(arr, obj%spr, res)
+    end subroutine
+      
+    subroutine evaluate_tau_from_spr(obj, tau, arr, res)
+        type(IR), intent(in) :: obj
+        double precision, intent(in) :: tau(:)
+        complex(kind(0d0)), intent (in) :: arr(:, :)
+        complex(kind(0d0)), intent(out) :: res(:, :)
+        double precision :: kernel
+        integer :: ntau, nt, p, t, l1, l2
+        !
+        ntau = size(tau)
+        nt = size(res, 2)
+        IF (ntau .NE. nt) stop 'wrong number of columns of output array.'
+        l1 = size(arr, 1)
+        l2 = size(res, 1)
+        IF (l1 .NE. l2) stop 'wrong number of rows of output array.'
+        !
+        do t = 1, ntau
+          if ((tau(t) < 0.0d0) .OR. (obj%beta < tau(t))) then
+            stop 'tau must be in [0, beta].'
+          end if
+        end do
+        !
+        res(:, :) = (0d0, 0d0)
+        !
+        do t = 1, ntau
+            do p = 1, obj%nomega
+                if (obj%omega(p) < 0) then
+                    kernel = exp( (obj%beta - tau(t)) * obj%omega(p)) / (exp(obj%beta * obj%omega(p)) + 1.0d0) 
+                else
+                    kernel = exp(- tau(t) * obj%omega(p)) / (1.0d0 + exp(- obj%beta * obj%omega(p))) 
+                end if
+                res(:, t) = res(:, t) - kernel * arr(:, p)
+            end do
+        end do
+        !
+    end subroutine
+      
+    subroutine evaluate_matsubara_f_from_spr(obj, freq, arr, res)
+        type(IR), intent(in) :: obj
+        integer, intent(in) :: freq(:)
+        complex(kind(0d0)), intent (in) :: arr(:, :)
+        complex(kind(0d0)), intent(out) :: res(:, :)
+        complex(kind(0d0)), PARAMETER :: ci  = (0.0d0, 1.0d0)
+        double precision, PARAMETER :: pi = 4.0d0*ATAN(1.0d0)
+        complex(kind(0d0)) :: cfreq
+        complex(kind(0d0)) :: kernel
+        integer :: nfreq, nf, p, n, l1, l2
+        !
+        nfreq = size(freq)
+        nf = size(res, 2)
+        IF (nfreq .NE. nf) stop 'wrong number of columns of output array.'
+        l1 = size(arr, 1)
+        l2 = size(res, 1)
+        IF (l1 .NE. l2) stop 'wrong number of rows of output array.'
+        !
+        do n = 1, nfreq
+          if (MOD(freq(n), 2) == 0) stop 'one of input integers is not odd.'
+        end do
+        !
+        res(:, :) = (0d0, 0d0)
+        !
+        do n = 1, nfreq
+            cfreq = ci * pi * REAL(freq(n), kind(0d0)) / obj%beta
+            do p = 1, obj%nomega
+                kernel = 1.0d0 / (cfreq - obj%omega(p))
+                res(:, n) = res(:, n) + kernel * arr(:, p)
+            end do
+        end do
+        !
+    end subroutine
+
+    subroutine evaluate_matsubara_b_from_spr(obj, freq, arr, res)
+        type(IR), intent(in) :: obj
+        integer, intent(in) :: freq(:)
+        complex(kind(0d0)), intent (in) :: arr(:, :)
+        complex(kind(0d0)), intent(out) :: res(:, :)
+        complex(kind(0d0)), PARAMETER :: ci  = (0.0d0, 1.0d0)
+        double precision, PARAMETER :: pi = 4.0d0*ATAN(1.0d0)
+        complex(kind(0d0)) :: cfreq
+        complex(kind(0d0)) :: kernel
+        integer :: nfreq, nf, p, n, l1, l2
+        !
+        nfreq = size(freq)
+        nf = size(res, 2)
+        IF (nfreq .NE. nf) stop 'wrong number of columns of output array.'
+        l1 = size(arr, 1)
+        l2 = size(res, 1)
+        IF (l1 .NE. l2) stop 'wrong number of rows of output array.'
+        !
+        do n = 1, nfreq
+          if (MOD(freq(n), 2) .ne. 0) stop 'one of input integers is not even.'
+        end do
+        !
+        res(:, :) = (0d0, 0d0)
+        !
+        do n = 1, nfreq
+            cfreq = ci * pi * REAL(freq(n), kind(0d0)) / obj%beta
+            do p = 1, obj%nomega
+                kernel = TANH(5.0d-1 * obj%beta * obj%omega(p)) / (cfreq - obj%omega(p))
+                res(:, n) = res(:, n) + kernel * arr(:, p)
+            end do
+        end do
+        !
+    end subroutine
 
 end module

--- a/sparse_ir.f90
+++ b/sparse_ir.f90
@@ -98,19 +98,6 @@ module sparse_ir
     subroutine finalize_ir(obj)
         type(IR) :: obj
 
-        if (allocated(obj%x)) deallocate(obj%x)
-        if (allocated(obj%tau)) deallocate(obj%tau)
-        if (allocated(obj%s)) deallocate(obj%s)
-        if (allocated(obj%freq_f)) deallocate(obj%freq_f)
-        if (allocated(obj%freq_b)) deallocate(obj%freq_b)
-        if (allocated(obj%u_data)) deallocate(obj%u_data)
-        if (allocated(obj%uhat_f_data)) deallocate(obj%uhat_f_data)
-        if (allocated(obj%uhat_b_data)) deallocate(obj%uhat_b_data)
-        if (allocated(obj%y)) deallocate(obj%y)
-        if (allocated(obj%omega)) deallocate(obj%omega)
-        if (allocated(obj%v_data)) deallocate(obj%v_data)
-        if (allocated(obj%spr_data)) deallocate(obj%spr_data)
-
         if (associated(obj%x)) nullify(obj%x)
         if (associated(obj%tau)) nullify(obj%tau)
         if (associated(obj%s)) nullify(obj%s)
@@ -132,12 +119,7 @@ module sparse_ir
 
     subroutine finalize_dmat(dmat)
         type(DecomposedMatrix) :: dmat
-      
-        if (allocated(dmat%a)) deallocate(dmat%a)
-        if (allocated(dmat%inv_s)) deallocate(dmat%inv_s)
-        if (allocated(dmat%ut)) deallocate(dmat%ut)
-        if (allocated(dmat%v)) deallocate(dmat%v)
-      
+           
         if (associated(dmat%a)) nullify(dmat%a)
         if (associated(dmat%inv_s)) nullify(dmat%inv_s)
         if (associated(dmat%ut)) nullify(dmat%ut)
@@ -426,10 +408,12 @@ module sparse_ir
         complex(kind(0d0)), intent (in) :: arr(:, :)
         complex(kind(0d0)), intent(out) :: res(:, :)
         complex(kind(0d0)), PARAMETER :: ci  = (0.0d0, 1.0d0)
-        double precision, PARAMETER :: pi = 4.0d0*ATAN(1.0d0)
+        double precision :: PI
         complex(kind(0d0)) :: cfreq
         complex(kind(0d0)) :: kernel
         integer :: nfreq, nf, p, n, l1, l2
+        !
+        PI =4.D0*DATAN(1.D0)
         !
         nfreq = size(freq)
         nf = size(res, 2)
@@ -460,10 +444,12 @@ module sparse_ir
         complex(kind(0d0)), intent (in) :: arr(:, :)
         complex(kind(0d0)), intent(out) :: res(:, :)
         complex(kind(0d0)), PARAMETER :: ci  = (0.0d0, 1.0d0)
-        double precision, PARAMETER :: pi = 4.0d0*ATAN(1.0d0)
+        double precision :: PI
         complex(kind(0d0)) :: cfreq
         complex(kind(0d0)) :: kernel
         integer :: nfreq, nf, p, n, l1, l2
+        !
+        PI =4.D0*DATAN(1.D0)
         !
         nfreq = size(freq)
         nf = size(res, 2)

--- a/sparse_ir.f90
+++ b/sparse_ir.f90
@@ -473,5 +473,39 @@ module sparse_ir
         end do
         !
     end subroutine
+    
+    subroutine system_mem_usage(valueRSS)
+#if defined (__INTEL)
+        use ifport !if on intel compiler
+#endif
+        character(len=30) :: count_char,pid_char, dummy
+        character(len=200) :: filename
+        character(len=200) :: command
+        integer :: count,pid,res
+        character(len=50), intent(out) :: valueRSS
+        
+        call system_clock(count)
+        
+        pid=getpid()
+        
+        write(count_char,'(I10)') count
+        write(pid_char,'(I10)') pid
+        
+        filename='~/tmp/mem_use.'//trim(count_char)
+        
+        command='cat /proc/'//trim(adjustl(pid_char))//'/status >'//trim(adjustl(filename))
+        
+        res=system(command)
+        
+        command='cat '//trim(adjustl(filename))//' | grep RSS > ~/tmp/rss_use.'//trim(count_char)
+        
+        res=system(command)
+        
+        open(unit=100, file='~/tmp/rss_use.'//trim(count_char))
+        read(100,*) dummy, valueRSS
+        close(100)
+        
+        return
+    end subroutine
 
 end module

--- a/sparse_ir.f90
+++ b/sparse_ir.f90
@@ -188,6 +188,8 @@ module sparse_ir
 
         dmat%a = a
         dmat%inv_s_dl(1:ns) = 1.0D0 / s(1:ns)
+        ! inv_s temporarily stores the same data of inv_s_dl
+        dmat%inv_s(1:ns) = dmat%inv_s_dl(1:ns)
         dmat%ut(1:ns, 1:m) = conjg(transpose(u(1:m, 1:ns)))
         dmat%v(1:n, 1:ns) = conjg(transpose(vt(1:ns, 1:n)))
         dmat%m = size(a, 1)
@@ -246,6 +248,8 @@ module sparse_ir
 
         dmat%a = a
         dmat%inv_s_dl(1:ns) = 1.0D0 / s(1:ns)
+        ! inv_s temporarily stores the same data of inv_s_dl
+        dmat%inv_s(1:ns) = dmat%inv_s_dl(1:ns)
         dmat%ut(1:ns, 1:m) = conjg(transpose(u(1:m, 1:ns)))
         dmat%v(1:n, 1:ns) = conjg(transpose(vt(1:ns, 1:n)))
         dmat%m = size(a, 1)

--- a/sparse_ir.f90
+++ b/sparse_ir.f90
@@ -191,6 +191,7 @@ module sparse_ir
         allocate(dmat%ut(ns, m))
         allocate(dmat%v(n, ns))
 
+        ! dmat%a temporarily stores the same data of input a
         dmat%a = a
         dmat%inv_s_dl(1:ns) = 1.0D0 / s(1:ns)
         ! inv_s temporarily stores the same data of inv_s_dl
@@ -251,6 +252,7 @@ module sparse_ir
         allocate(dmat%ut(ns, m))
         allocate(dmat%v(n, ns))
 
+        ! dmat%a temporarily stores the same data of input a
         dmat%a = a
         dmat%inv_s_dl(1:ns) = 1.0D0 / s(1:ns)
         ! inv_s temporarily stores the same data of inv_s_dl

--- a/sparse_ir.f90
+++ b/sparse_ir.f90
@@ -473,39 +473,5 @@ module sparse_ir
         end do
         !
     end subroutine
-    
-    subroutine system_mem_usage(valueRSS)
-#if defined (__INTEL)
-        use ifport !if on intel compiler
-#endif
-        character(len=30) :: count_char,pid_char, dummy
-        character(len=200) :: filename
-        character(len=200) :: command
-        integer :: count,pid,res
-        character(len=50), intent(out) :: valueRSS
-        
-        call system_clock(count)
-        
-        pid=getpid()
-        
-        write(count_char,'(I10)') count
-        write(pid_char,'(I10)') pid
-        
-        filename='~/tmp/mem_use.'//trim(count_char)
-        
-        command='cat /proc/'//trim(adjustl(pid_char))//'/status >'//trim(adjustl(filename))
-        
-        res=system(command)
-        
-        command='cat '//trim(adjustl(filename))//' | grep RSS > ~/tmp/rss_use.'//trim(count_char)
-        
-        res=system(command)
-        
-        open(unit=100, file='~/tmp/rss_use.'//trim(count_char))
-        read(100,*) dummy, valueRSS
-        close(100)
-        
-        return
-    end subroutine
 
 end module

--- a/sparse_ir.f90
+++ b/sparse_ir.f90
@@ -325,7 +325,7 @@ module sparse_ir
 
         complex(kind(0d0)), allocatable :: ut_arr(:, :)
 
-        integer :: nb, m, n, ns, i, j, info
+        integer :: nb, m, n, ns, i, j
 
         ! ut(ns, m)
         ! v(n, ns)

--- a/sparse_ir.f90
+++ b/sparse_ir.f90
@@ -95,36 +95,36 @@ module sparse_ir
         obj%spr = decompose2(sqrt(5.0d-1*beta)*obj%spr_data, obj%eps_svd)
     end subroutine
 
-    subroutine finalize_ir(obj)
-        type(IR) :: obj
+    !subroutine finalize_ir(obj)
+    !    type(IR) :: obj
+    !
+    !    if (associated(obj%x)) nullify(obj%x)
+    !    if (associated(obj%tau)) nullify(obj%tau)
+    !    if (associated(obj%s)) nullify(obj%s)
+    !    if (associated(obj%freq_f)) nullify(obj%freq_f)
+    !    if (associated(obj%freq_b)) nullify(obj%freq_b)
+    !    if (associated(obj%u_data)) nullify(obj%u_data)
+    !    if (associated(obj%uhat_f_data)) nullify(obj%uhat_f_data)
+    !    if (associated(obj%uhat_b_data)) nullify(obj%uhat_b_data)
+    !    if (associated(obj%y)) nullify(obj%y)
+    !    if (associated(obj%omega)) nullify(obj%omega)
+    !    if (associated(obj%v_data)) nullify(obj%v_data)
+    !    if (associated(obj%spr_data)) nullify(obj%spr_data)
+    !
+    !    call finalize_dmat(obj%u)
+    !    call finalize_dmat(obj%uhat_f)
+    !    call finalize_dmat(obj%uhat_b)
+    !    call finalize_dmat(obj%spr)
+    !end subroutine
 
-        if (associated(obj%x)) nullify(obj%x)
-        if (associated(obj%tau)) nullify(obj%tau)
-        if (associated(obj%s)) nullify(obj%s)
-        if (associated(obj%freq_f)) nullify(obj%freq_f)
-        if (associated(obj%freq_b)) nullify(obj%freq_b)
-        if (associated(obj%u_data)) nullify(obj%u_data)
-        if (associated(obj%uhat_f_data)) nullify(obj%uhat_f_data)
-        if (associated(obj%uhat_b_data)) nullify(obj%uhat_b_data)
-        if (associated(obj%y)) nullify(obj%y)
-        if (associated(obj%omega)) nullify(obj%omega)
-        if (associated(obj%v_data)) nullify(obj%v_data)
-        if (associated(obj%spr_data)) nullify(obj%spr_data)
-
-        call finalize_dmat(obj%u)
-        call finalize_dmat(obj%uhat_f)
-        call finalize_dmat(obj%uhat_b)
-        call finalize_dmat(obj%spr)
-    end subroutine
-
-    subroutine finalize_dmat(dmat)
-        type(DecomposedMatrix) :: dmat
-           
-        if (associated(dmat%a)) nullify(dmat%a)
-        if (associated(dmat%inv_s)) nullify(dmat%inv_s)
-        if (associated(dmat%ut)) nullify(dmat%ut)
-        if (associated(dmat%v)) nullify(dmat%v)
-    end subroutine
+    !subroutine finalize_dmat(dmat)
+    !    type(DecomposedMatrix) :: dmat
+    !
+    !    if (associated(dmat%a)) nullify(dmat%a)
+    !    if (associated(dmat%inv_s)) nullify(dmat%inv_s)
+    !    if (associated(dmat%ut)) nullify(dmat%ut)
+    !    if (associated(dmat%v)) nullify(dmat%v)
+    !end subroutine
 
     ! SVD of matrix a. Singular values smaller than eps * the largest one are dropped.
     function decompose(a, eps) result(dmat)

--- a/test_sparse_ir.f90
+++ b/test_sparse_ir.f90
@@ -8,9 +8,13 @@ program main
     call test_under_fitting()
     call test_over_fitting()
     call test_fermion(.true.)
-    !call test_boson(.true.)
-    !call test_fermion(.false.)
-    !call test_boson(.false.)
+    call test_boson(.true.)
+    call test_fermion_spr(.true.)
+    call test_boson_spr(.true.)
+    call test_fermion(.false.)
+    call test_boson(.false.)
+    call test_fermion_spr(.false.)
+    call test_boson_spr(.false.)
 
     contains
 
@@ -95,7 +99,7 @@ program main
         double precision, parameter :: beta = lambda/wmax, omega0 = 1.d0/beta
         double precision, parameter :: eps = 1.d-1**ndigit
 
-        complex(kind(0d0)),allocatable :: giv(:,:), gl_ref(:, :), gl_matsu(:, :), gl_tau(:, :), gtau(:, :), &
+        complex(kind(0d0)),allocatable :: giv(:,:), gl_matsu(:, :), gl_tau(:, :), gtau(:, :), &
             gtau_reconst(:, :), giv_reconst(:, :)
         integer n, t, l
 
@@ -121,7 +125,6 @@ program main
         !   G(τ=0) = - exp(-τ ω0)/(1+exp(-β ω0)),
         allocate(giv(1, ir_obj%nfreq_f))
         allocate(gtau(1, ir_obj%ntau))
-        allocate(gl_ref(1, ir_obj%size))
         allocate(gl_matsu(1, ir_obj%size))
         allocate(gl_tau(1, ir_obj%size))
         allocate(gtau_reconst(1, ir_obj%ntau))
@@ -157,7 +160,9 @@ program main
             stop "gtau do not match!"
         end if
 
-        deallocate(giv, gtau, gl_ref, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
+        deallocate(giv, gtau, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
+
+        call finalize_ir(ir_obj)
     end subroutine
 
 
@@ -173,7 +178,7 @@ program main
         double precision, parameter :: beta = lambda/wmax, omega0 = 1.d0/beta
         double precision, parameter :: eps = 1.d-1**ndigit
 
-        complex(kind(0d0)),allocatable :: giv(:,:), gl_ref(:, :), gl_matsu(:, :), gl_tau(:, :), gtau(:, :), &
+        complex(kind(0d0)),allocatable :: giv(:,:), gl_matsu(:, :), gl_tau(:, :), gtau(:, :), &
             gtau_reconst(:, :), giv_reconst(:, :)
         integer n, t
 
@@ -199,7 +204,6 @@ program main
         !   G(τ=0) = - exp(-τ ω0)/(1-exp(-β ω0)),
         allocate(giv(1, ir_obj%nfreq_b))
         allocate(gtau(1, ir_obj%ntau))
-        allocate(gl_ref(1, ir_obj%size))
         allocate(gl_matsu(1, ir_obj%size))
         allocate(gl_tau(1, ir_obj%size))
         allocate(gtau_reconst(1, ir_obj%ntau))
@@ -236,7 +240,207 @@ program main
             stop "gtau do not match!"
         end if
 
-        deallocate(giv, gtau, gl_ref, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
+        deallocate(giv, gtau, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
+        
+        call finalize_ir(ir_obj)
+    end subroutine
+
+    ! fermion
+    subroutine test_fermion_spr(preset)
+        logical, intent(in) :: preset
+        type(IR) :: ir_obj
+        integer, parameter :: ndigit = 10, nlambda = 4
+        double precision, parameter :: lambda = 1.d1 ** nlambda
+        double precision, parameter :: wmax = 1.d0
+        double precision :: PI
+
+        double precision, parameter :: beta = lambda/wmax, omega0 = 1.d0/beta
+        double precision, parameter :: eps = 1.d-1**ndigit
+        integer, parameter :: ntau_spr = 200, nfreq_spr = 200
+
+        complex(kind(0d0)),allocatable :: giv_smpl(:,:), gl_matsu(:, :), gl_tau(:, :), gtau_smpl(:, :), &
+            gtau_reconst(:, :), giv_reconst(:, :), g_spr(:, :), giv_ref(:,:), gtau_ref(:,:)
+        integer, allocatable :: freq(:) 
+        double precision, allocatable :: tau(:)
+        integer n, t, l
+
+        PI =4.D0*DATAN(1.D0)
+
+        if (preset) then
+            ir_obj = mk_ir_preset(nlambda, ndigit, beta)
+        else
+            open(99, file='ir_nlambda4_ndigit10.dat', status='old')
+            ir_obj = read_ir(99, beta)
+            close(99)
+        end if
+
+        if (abs(ir_obj%beta - beta) > 1d-10) then
+            stop "beta does not match"
+        end if
+        if (abs(ir_obj%wmax - wmax) > 1d-10) then
+            stop "wmax does not match"
+        end if
+
+        ! With ω0 = 1/β,
+        !   G(iv) = 1/(iv - ω0),
+        !   G(τ=0) = - exp(-τ ω0)/(1+exp(-β ω0)),
+        allocate(giv_smpl(1, ir_obj%nfreq_f))
+        allocate(gtau_smpl(1, ir_obj%ntau))
+        allocate(gl_matsu(1, ir_obj%size))
+        allocate(gl_tau(1, ir_obj%size))
+        allocate(g_spr(1, ir_obj%nomega))
+        allocate(giv_ref(1, nfreq_spr))
+        allocate(gtau_ref(1, ntau_spr))
+        allocate(gtau_reconst(1, ntau_spr))
+        allocate(giv_reconst(1, nfreq_spr))
+        allocate(freq(nfreq_spr))
+        allocate(tau(ntau_spr))
+
+        ! From Matsubara
+        do n = 1, ir_obj%nfreq_f
+            giv_smpl(1, n) = 1.d0/(cmplx(0d0, PI*ir_obj%freq_f(n)/beta, kind(0d0)) - omega0)
+        end do
+        call fit_matsubara_f(ir_obj, giv_smpl, gl_matsu)
+
+        ! From tau
+        !   G(τ=0) = - exp(-τ ω0)/(1+exp(-β ω0)),
+        do t = 1, ir_obj%ntau
+            gtau_smpl(1, t) = - exp(-ir_obj%tau(t) * omega0)/(1.d0 + exp(-beta * omega0))
+        end do
+        call fit_tau(ir_obj, gtau_smpl, gl_tau)
+
+        !do l = 1, ir_obj%size
+            !write(*,*) real(gl_matsu(1,l)), real(gl_tau(1,l))
+        !end do
+        if (maxval(abs(gl_matsu - gl_tau)) > 1d2*eps) then
+            stop "gl_matsu and gl_tau do not match!"
+        end if
+
+        call to_spr (ir_obj, gl_matsu, g_spr) 
+
+        do n = 1, nfreq_spr
+            freq(n) = -nfreq_spr + 2 * (n) - 1
+            giv_ref(1, n) = 1.d0/(cmplx(0d0, PI*freq(n)/beta, kind(0d0)) - omega0)
+        end do
+
+        call evaluate_matsubara_f_from_spr(ir_obj, freq, g_spr, giv_reconst)
+        if (maxval(abs(giv_ref - giv_reconst)) > 1d3*eps) then
+            stop "giv do not match!"
+        end if
+
+        do n = 1, ntau_spr
+            tau(n) = beta * DBLE(n) / DBLE(ntau_spr + 1)
+            gtau_ref(1, n) = - exp(-tau(n) * omega0)/(1.d0 + exp(-beta * omega0))
+        end do
+
+        call evaluate_tau_from_spr(ir_obj, tau, g_spr, gtau_reconst)
+        if (maxval(abs(gtau_ref - gtau_reconst)) > 1d3*eps) then
+            stop "gtau do not match!"
+        end if
+
+        deallocate(giv_smpl, gtau_smpl, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
+        deallocate(giv_ref, gtau_ref, g_spr, freq, tau)
+        
+        call finalize_ir(ir_obj)
+    end subroutine
+
+    ! boson
+    subroutine test_boson_spr(preset)
+        logical, intent(in) :: preset
+        type(IR) :: ir_obj
+        integer, parameter :: ndigit = 10, nlambda = 4
+        double precision, parameter :: lambda = 1.d1 ** nlambda
+        double precision, parameter :: wmax = 1.d0
+        double precision :: PI
+
+        double precision, parameter :: beta = lambda/wmax, omega0 = 1.d0/beta
+        double precision, parameter :: eps = 1.d-1**ndigit
+        integer, parameter :: ntau_spr = 200, nfreq_spr = 200
+
+        complex(kind(0d0)),allocatable :: giv_smpl(:,:), gl_matsu(:, :), gl_tau(:, :), gtau_smpl(:, :), &
+            gtau_reconst(:, :), giv_reconst(:, :), g_spr(:, :), giv_ref(:,:), gtau_ref(:,:)
+        integer, allocatable :: freq(:) 
+        double precision, allocatable :: tau(:)
+        integer n, t, l
+
+        PI =4.D0*DATAN(1.D0)
+
+        if (preset) then
+            ir_obj = mk_ir_preset(nlambda, ndigit, beta)
+        else
+            open(99, file='ir_nlambda4_ndigit10.dat', status='old')
+            ir_obj = read_ir(99, beta)
+            close(99)
+        end if
+
+        if (abs(ir_obj%beta - beta) > 1d-10) then
+            stop "beta does not match"
+        end if
+        if (abs(ir_obj%wmax - wmax) > 1d-10) then
+            stop "wmax does not match"
+        end if
+
+        ! With ω0 = 1/β,
+        !   G(iv) = 1/(iv - ω0),
+        !   G(τ=0) = - exp(-τ ω0)/(1+exp(-β ω0)),
+        allocate(giv_smpl(1, ir_obj%nfreq_b))
+        allocate(gtau_smpl(1, ir_obj%ntau))
+        allocate(gl_matsu(1, ir_obj%size))
+        allocate(gl_tau(1, ir_obj%size))
+        allocate(g_spr(1, ir_obj%nomega))
+        allocate(giv_ref(1, nfreq_spr))
+        allocate(gtau_ref(1, ntau_spr))
+        allocate(gtau_reconst(1, ntau_spr))
+        allocate(giv_reconst(1, nfreq_spr))
+        allocate(freq(nfreq_spr))
+        allocate(tau(ntau_spr))
+
+        ! From Matsubara
+        do n = 1, ir_obj%nfreq_b
+            giv_smpl(1, n) = 1.d0/(cmplx(0d0, PI*ir_obj%freq_b(n)/beta, kind(0d0)) - omega0)
+        end do
+        call fit_matsubara_b(ir_obj, giv_smpl, gl_matsu)
+
+        ! From tau
+        !   G(τ=0) = - exp(-τ ω0)/(1+exp(-β ω0)),
+        do t = 1, ir_obj%ntau
+            gtau_smpl(1, t) = - exp(-ir_obj%tau(t) * omega0)/(1.d0 - exp(-beta * omega0))
+        end do
+        call fit_tau(ir_obj, gtau_smpl, gl_tau)
+
+        !do l = 1, ir_obj%size
+            !write(*,*) real(gl_matsu(1,l)), real(gl_tau(1,l))
+        !end do
+        if (maxval(abs(gl_matsu - gl_tau)) > 1d2*eps) then
+            stop "gl_matsu and gl_tau do not match!"
+        end if
+
+        call to_spr (ir_obj, gl_matsu, g_spr) 
+
+        do n = 1, nfreq_spr
+            freq(n) = -nfreq_spr + 2 * (n)
+            giv_ref(1, n) = 1.d0/(cmplx(0d0, PI*freq(n)/beta, kind(0d0)) - omega0)
+        end do
+
+        call evaluate_matsubara_b_from_spr(ir_obj, freq, g_spr, giv_reconst)
+        if (maxval(abs(giv_ref - giv_reconst)) > 1d3*eps) then
+            stop "giv do not match!"
+        end if
+
+        do n = 1, ntau_spr
+            tau(n) = beta * DBLE(n) / DBLE(ntau_spr + 1)
+            gtau_ref(1, n) = - exp(-tau(n) * omega0)/(1.d0 - exp(-beta * omega0))
+        end do
+
+        call evaluate_tau_from_spr(ir_obj, tau, g_spr, gtau_reconst)
+        if (maxval(abs(gtau_ref - gtau_reconst)) > 1d3*eps) then
+            stop "gtau do not match!"
+        end if
+
+        deallocate(giv_smpl, gtau_smpl, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
+        deallocate(giv_ref, gtau_ref, g_spr, freq, tau)
+        
+        call finalize_ir(ir_obj)
     end subroutine
 
 end program

--- a/test_sparse_ir.f90
+++ b/test_sparse_ir.f90
@@ -39,6 +39,7 @@ program main
         end if
         !write(*, *) y
         !write(*, *) y_reconst
+        call finalize_dmat(dm)
     end subroutine
 
     subroutine test_over_fitting()
@@ -58,6 +59,7 @@ program main
         if (maxval(abs(y - y_reconst)) > 1e-12) then
             stop "y and y_reconst do not match!"
         end if
+        call finalize_dmat(dm)
     end subroutine
 
 
@@ -84,6 +86,7 @@ program main
         if (maxval(abs(y - y_reconst)) > 1e-12) then
             stop "y and y_reconst do not match!"
         end if
+        call finalize_dmat(dm)
     end subroutine
 
 

--- a/test_sparse_ir.f90
+++ b/test_sparse_ir.f90
@@ -162,7 +162,7 @@ program main
 
         deallocate(giv, gtau, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
 
-        !call finalize_ir(ir_obj)
+        call finalize_ir(ir_obj)
     end subroutine
 
 
@@ -242,7 +242,7 @@ program main
 
         deallocate(giv, gtau, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
         
-        !call finalize_ir(ir_obj)
+        call finalize_ir(ir_obj)
     end subroutine
 
     ! fermion
@@ -341,7 +341,7 @@ program main
         deallocate(giv_smpl, gtau_smpl, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
         deallocate(giv_ref, gtau_ref, g_spr, freq, tau)
         
-        !call finalize_ir(ir_obj)
+        call finalize_ir(ir_obj)
     end subroutine
 
     ! boson
@@ -440,7 +440,7 @@ program main
         deallocate(giv_smpl, gtau_smpl, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
         deallocate(giv_ref, gtau_ref, g_spr, freq, tau)
         
-        !call finalize_ir(ir_obj)
+        call finalize_ir(ir_obj)
     end subroutine
 
 end program

--- a/test_sparse_ir.f90
+++ b/test_sparse_ir.f90
@@ -162,7 +162,7 @@ program main
 
         deallocate(giv, gtau, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
 
-        call finalize_ir(ir_obj)
+        !call finalize_ir(ir_obj)
     end subroutine
 
 
@@ -242,7 +242,7 @@ program main
 
         deallocate(giv, gtau, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
         
-        call finalize_ir(ir_obj)
+        !call finalize_ir(ir_obj)
     end subroutine
 
     ! fermion
@@ -341,7 +341,7 @@ program main
         deallocate(giv_smpl, gtau_smpl, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
         deallocate(giv_ref, gtau_ref, g_spr, freq, tau)
         
-        call finalize_ir(ir_obj)
+        !call finalize_ir(ir_obj)
     end subroutine
 
     ! boson
@@ -440,7 +440,7 @@ program main
         deallocate(giv_smpl, gtau_smpl, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
         deallocate(giv_ref, gtau_ref, g_spr, freq, tau)
         
-        call finalize_ir(ir_obj)
+        !call finalize_ir(ir_obj)
     end subroutine
 
 end program

--- a/test_sparse_ir.f90
+++ b/test_sparse_ir.f90
@@ -101,7 +101,7 @@ program main
 
         complex(kind(0d0)),allocatable :: giv(:,:), gl_matsu(:, :), gl_tau(:, :), gtau(:, :), &
             gtau_reconst(:, :), giv_reconst(:, :)
-        integer n, t, l
+        integer n, t
 
         PI =4.D0*DATAN(1.D0)
 
@@ -262,7 +262,7 @@ program main
             gtau_reconst(:, :), giv_reconst(:, :), g_spr(:, :), giv_ref(:,:), gtau_ref(:,:)
         integer, allocatable :: freq(:) 
         double precision, allocatable :: tau(:)
-        integer n, t, l
+        integer n, t
 
         PI =4.D0*DATAN(1.D0)
 
@@ -361,7 +361,7 @@ program main
             gtau_reconst(:, :), giv_reconst(:, :), g_spr(:, :), giv_ref(:,:), gtau_ref(:,:)
         integer, allocatable :: freq(:) 
         double precision, allocatable :: tau(:)
-        integer n, t, l
+        integer n, t
 
         PI =4.D0*DATAN(1.D0)
 


### PR DESCRIPTION
Added some subroutines into `sparse_ir.f90`:
`finalize_ir` is to deallocate all the arrays related with IR.  
`decompose2` is almost the same as `decompose` but using `ZGESVD` instead of `ZGESDD`.
`to_spr` is to transform the expansion coefficients from IR to SPR.
`evaluate_matsubara_f_from_spr` is to reconstruct fermionic functions from corresponding SPR coefficients for arbitrary frequencies.
`evaluate_matsubara_b_from_spr` is to reconstruct bosonic functions from corresponding SPR coefficients for arbitrary frequencies.
`evaluate_tau_from_spr` is to reconstruct functions from corresponding SPR coefficients for arbitrary imaginary time.

Added two subroutines into `test_sparse_ir.f90` to check the reproducibility of SPR.

Please note:
1. The input frequencies must be given as odd/even integers for `evaluate_matsubara_{f/b}_from_spr`.
2. `set_beta` was changed not to call `decompose` when resetting `beta`; dimensionless matrices and inverses of dimensionless singular values are multiplied by the corresponding factors.
3. `evaluate_tau_from_spr` calculates the logistic kernel with avoiding the floating problem.
4. test.yml was edited to test with intel compiler.